### PR TITLE
Adding 0.10.1 message

### DIFF
--- a/PSAT-Command-Line-Interface.md
+++ b/PSAT-Command-Line-Interface.md
@@ -87,12 +87,15 @@ For a detailed understanding of the CLI options, you can use the `npm run cli --
 ```bash
 $ npm run cli -- --help
 
-> ps-analysis-tool@1.0.0 cli
+> ps-analysis-tool@0.10.1 cli
 > node packages/cli/dist/main.js --help
 
 Usage: npm run cli [website-url] -- [options]
 
 CLI to test a URL for 3p cookies.
+
+Arguments:
+  website-url                 The URL of a single site to analyze
 
 Options:
   -V, --version               output the version number


### PR DESCRIPTION
Updating the messages from the helper on the Wiki:

```bash
$ npm run cli -- --help

> ps-analysis-tool@0.10.1 cli
> node packages/cli/dist/main.js --help

Usage: npm run cli [website-url] -- [options]

CLI to test a URL for 3p cookies.

Arguments:
  website-url                 The URL of a single site to analyze

Options:
  -V, --version               output the version number
  -u, --url <url>             The URL of a single site to analyze
  -s, --source-url <url>      The URL of a sitemap or CSV to analyze
  -f, --file <path>           The path to a local file (CSV or XML sitemap) to analyze
  -n, --number-of-urls <num>  Limit the number of URLs to analyze (from sitemap or CSV)
  -d, --display               Flag for running CLI in non-headless mode (default: false)
  -v, --verbose               Enables verbose logging (default: false)
  -t, --tech                  Enables technology analysis (default: false)
  -o, --out-dir <path>        Directory to store analysis data (JSON, CSV, HTML) without launching the dashboard
  -i, --ignore-gdpr           Ignore automatically accepting the GDPR banner if present (default: false)
  -q, --quiet                 Skips all prompts; uses default options (default: false)
  -c, --concurrency <num>     Number of tabs to open in parallel during sitemap or CSV analysis (default: 3)
  -w, --wait <num>            Number of milliseconds to wait after the page is loaded before generating the report (default: 20000)
  -l, --locale <language>     Locale to use for the CLI, supported: en, hi, es, ja, ko, pt-BR (default: "en")
  -h, --help                  Display help for command

To learn more, visit our wiki: https://github.com/GoogleChromeLabs/ps-analysis-tool/wiki.
```