### PR TITLE
Add warning about accuracy of technology analysis in PSAT CLI

### DIFF
--- a/PSAT-Command-Line-Interface.md
+++ b/PSAT-Command-Line-Interface.md
@@ -70,7 +70,7 @@ To customize and change the behavior of the analysis of those reports, the CLI a
 > When using a URL with multiple parameters joined by ampersands (&), surround the entire URL with double quotes (") to avoid errors, the quote ensures that it treats entire URL as string. For example: `npm run cli -- -u "https://example.com?param1=value1&param2=value2"`.
 
 > [!WARNING]
-> The technology analysis may not be accurate for all sites. We recommend manual analysis of technologies used on the site for a more accurate report.
+> The technology analysis may not be accurate for all sites. We recommend a manual analysis of technologies used on the site for a more precise report.
 
 ### CLI Use Cases
 


### PR DESCRIPTION
Wapplyzer is not accurately detecting the technologies, comparatively wapplyzer website, so added a warning for the same in the wiki.