### PR TITLE
Update sidebar: replace 'Private Advertising' with 'Privacy Protection'

### DIFF
--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -31,7 +31,7 @@
   - [[Protected Audience]]
   - [[Attribution Reporting]]
   - [[Private Aggregation]]
-- [[Private Advertising]]
+- [[Privacy Protection]]
   - [[IP Protection]]
   - [[Bounce Tracking]]
   - [[User Agent Strings]]


### PR DESCRIPTION
Corrected Menu name from conflicts mishap 